### PR TITLE
change attribute order

### DIFF
--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -34,6 +34,8 @@ def main_function():
         collection['attributes'].append({'type':'discord','value':collection_discord})
     if collection_icon:
         collection['attributes'].append({'type':'icon','value':collection_icon})
+    if collection_banner:
+        collection['attributes'].append({'type':'banner','value':collection_banner})
 
 
     n_format = "CHIP-0007"
@@ -64,9 +66,10 @@ def main_function():
                 jsondata['name'] = name
                 jsondata['description'] = description
                 jsondata['sensitive_content'] = sensitive_content
-                jsondata['collection'] = collection
                 if indvdl_attributes == True:
                     jsondata['attributes'] = attributes_list
+                jsondata['collection'] = collection
+
 
                 with open(f"metadata/metadata{i}.json","w") as f:
                     f.write(json.dumps(jsondata, indent=4))
@@ -74,4 +77,3 @@ def main_function():
     
 if __name__ == "__main__":
     main_function()
-


### PR DESCRIPTION
I think something change in 1.5.0 as the metadata format that's generate_metadata.py creates, while technically valid JSON, results in the GUI and explorers unable to read the metadata.

The issue is the order of collection attributres and NFT attributes. I switched it around and the resulting metadata files work now.